### PR TITLE
Clarified use of all-capitalized key words and declared non-usage for EIP-1

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -17,11 +17,16 @@ We intend EIPs to be the primary mechanisms for proposing new features, for coll
 
 For Ethereum implementers, EIPs are a convenient way to track the progress of their implementation. Ideally each implementation maintainer would list the EIPs that they have implemented. This will give end users a convenient way to know the current status of a given implementation or library.
 
+## Specification
+
+Capitalized key words as described in RFC 2119 and RFC 8174 are deliberately not in effect in this document. For example, “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” are not in use per the RFCs.
+
 ## EIP Types
 
 There are three types of EIP:
 
 - A **Standards Track EIP** describes any change that affects most or all Ethereum implementations, such as—a change to the network protocol, a change in block or transaction validity rules, proposed application standards/conventions, or any change or addition that affects the interoperability of applications using Ethereum. Standards Track EIPs consist of three parts—a design document, an implementation, and (if warranted) an update to the [formal specification](https://github.com/ethereum/yellowpaper). Furthermore, Standards Track EIPs can be broken down into the following categories:
+
   - **Core**: improvements requiring a consensus fork (e.g. [EIP-5](./eip-5.md), [EIP-101](./eip-101.md)), as well as changes that are not necessarily consensus critical but may be relevant to [“core dev” discussions](https://github.com/ethereum/pm) (for example, [EIP-90], and the miner/node strategy changes 2, 3, and 4 of [EIP-86](./eip-86.md)).
   - **Networking**: includes improvements around [devp2p](https://github.com/ethereum/devp2p/blob/readme-spec-links/rlpx.md) ([EIP-8](./eip-8.md)) and [Light Ethereum Subprotocol](https://ethereum.org/en/developers/docs/nodes-and-clients/#light-node), as well as proposed improvements to network protocol specifications of [whisper](https://github.com/ethereum/go-ethereum/issues/16013#issuecomment-364639309) and [swarm](https://github.com/ethereum/go-ethereum/pull/2959).
   - **Interface**: includes improvements around language-level standards like method names ([EIP-6](./eip-6.md)) and [contract ABIs](https://docs.soliditylang.org/en/develop/abi-spec.html).
@@ -47,7 +52,7 @@ REVERT (0xfe)
 
 ### Shepherding an EIP
 
-Parties involved in the process are you, the champion or *EIP author*, the [*EIP editors*](#eip-editors), and the [*Ethereum Core Developers*](https://github.com/ethereum/pm).
+Parties involved in the process are you, the champion or _EIP author_, the [_EIP editors_](#eip-editors), and the [_Ethereum Core Developers_](https://github.com/ethereum/pm).
 
 Before you begin writing a formal EIP, you should vet your idea. Ask the Ethereum community first if an idea is original to avoid wasting time on something that will be rejected based on prior research. It is thus recommended to open a discussion thread on [the Ethereum Magicians forum](https://ethereum-magicians.org/) to do this.
 
@@ -57,7 +62,7 @@ Once the idea has been vetted, your next responsibility will be to present (by m
 
 For Core EIPs, given that they require client implementations to be considered **Final** (see "EIPs Process" below), you will need to either provide an implementation for clients or convince clients to implement your EIP.
 
-The best way to get client implementers to review your EIP is to present it on an AllCoreDevs call. You can request to do so by posting a comment linking your EIP on an [AllCoreDevs agenda GitHub Issue](https://github.com/ethereum/pm/issues).  
+The best way to get client implementers to review your EIP is to present it on an AllCoreDevs call. You can request to do so by posting a comment linking your EIP on an [AllCoreDevs agenda GitHub Issue](https://github.com/ethereum/pm/issues).
 
 The AllCoreDevs call serves as a way for client implementers to do three things. First, to discuss the technical merits of EIPs. Second, to gauge what other clients will be implementing. Third, to coordinate EIP implementation for network upgrades.
 
@@ -65,7 +70,7 @@ These calls generally result in a "rough consensus" around what EIPs should be i
 
 :warning: The EIPs process and AllCoreDevs call were not designed to address contentious non-technical issues, but, due to the lack of other ways to address these, often end up entangled in them. This puts the burden on client implementers to try and gauge community sentiment, which hinders the technical coordination function of EIPs and AllCoreDevs calls. If you are shepherding an EIP, you can make the process of building community consensus easier by making sure that [the Ethereum Magicians forum](https://ethereum-magicians.org/) thread for your EIP includes or links to as much of the community discussion as possible and that various stakeholders are well-represented.
 
-*In short, your role as the champion is to write the EIP using the style and format described below, shepherd the discussions in the appropriate forums, and build community consensus around the idea.*
+_In short, your role as the champion is to write the EIP using the style and format described below, shepherd the discussions in the appropriate forums, and build community consensus around the idea._
 
 ### EIP Process
 
@@ -85,11 +90,11 @@ If this period results in necessary normative changes it will revert the EIP to 
 
 **Final** - This EIP represents the final standard. A Final EIP exists in a state of finality and should only be updated to correct errata and add non-normative clarifications.
 
-A PR moving an EIP from Last Call to Final SHOULD contain no changes other than the status update. Any content or editorial proposed change SHOULD be separate from this status-updating PR and committed prior to it.
+A PR moving an EIP from Last Call to Final should contain no changes other than the status update. Any content or editorial proposed change should be separate from this status-updating PR and committed prior to it.
 
 **Stagnant** - Any EIP in `Draft` or `Review` or `Last Call` if inactive for a period of 6 months or greater is moved to `Stagnant`. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to `Draft` or its earlier status. If not resurrected, a proposal may stay forever in this status.
 
->*EIP Authors are notified of any algorithmic change to the status of their EIP*
+> _EIP Authors are notified of any algorithmic change to the status of their EIP_
 
 **Withdrawn** - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.
 
@@ -101,14 +106,14 @@ Each EIP should have the following parts:
 
 - Preamble - RFC 822 style headers containing metadata about the EIP, including the EIP number, a short descriptive title (limited to a maximum of 44 characters), a description (limited to a maximum of 140 characters), and the author details. Irrespective of the category, the title and description should not include EIP number. See [below](./eip-1.md#eip-header-preamble) for details.
 - Abstract - Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
-- Motivation *(optional)* - A motivation section is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. This section may be omitted if the motivation is evident.
+- Motivation _(optional)_ - A motivation section is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. This section may be omitted if the motivation is evident.
 - Specification - The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (besu, erigon, ethereumjs, go-ethereum, nethermind, or others).
 - Rationale - The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale should discuss important objections or concerns raised during discussion around the EIP.
-- Backwards Compatibility *(optional)* - All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their consequences. The EIP must explain how the author proposes to deal with these incompatibilities. This section may be omitted if the proposal does not introduce any backwards incompatibilities, but this section must be included if backward incompatibilities exist.
-- Test Cases *(optional)* - Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Tests should either be inlined in the EIP as data (such as input/expected output pairs, or included in `../assets/eip-###/<filename>`. This section may be omitted for non-Core proposals.
-- Reference Implementation *(optional)* - An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification. This section may be omitted for all EIPs.
+- Backwards Compatibility _(optional)_ - All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their consequences. The EIP must explain how the author proposes to deal with these incompatibilities. This section may be omitted if the proposal does not introduce any backwards incompatibilities, but this section must be included if backward incompatibilities exist.
+- Test Cases _(optional)_ - Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Tests should either be inlined in the EIP as data (such as input/expected output pairs, or included in `../assets/eip-###/<filename>`. This section may be omitted for non-Core proposals.
+- Reference Implementation _(optional)_ - An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification. This section may be omitted for all EIPs.
 - Security Considerations - All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life-cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
-- Copyright Waiver - All EIPs must be in the public domain. The copyright waiver MUST link to the license file and use the following wording: `Copyright and related rights waived via [CC0](../LICENSE.md).`
+- Copyright Waiver - All EIPs must be in the public domain. The copyright waiver must link to the license file and use the following wording: `Copyright and related rights waived via [CC0](../LICENSE.md).`
 
 ## EIP Formats and Templates
 
@@ -118,29 +123,29 @@ EIPs should be written in [markdown](https://github.com/adam-p/markdown-here/wik
 
 Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style header preamble, preceded and followed by three hyphens (`---`). This header is also termed ["front matter" by Jekyll](https://jekyllrb.com/docs/front-matter/). The headers must appear in the following order.
 
-`eip`: *EIP number*
+`eip`: _EIP number_
 
-`title`: *The EIP title is a few words, not a complete sentence*
+`title`: _The EIP title is a few words, not a complete sentence_
 
-`description`: *Description is one full (short) sentence*
+`description`: _Description is one full (short) sentence_
 
-`author`: *The list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.*
+`author`: _The list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below._
 
-`discussions-to`: *The url pointing to the official discussion thread*
+`discussions-to`: _The url pointing to the official discussion thread_
 
-`status`: *Draft, Review, Last Call, Final, Stagnant, Withdrawn, Living*
+`status`: _Draft, Review, Last Call, Final, Stagnant, Withdrawn, Living_
 
-`last-call-deadline`: *The date last call period ends on* (Optional field, only needed when status is `Last Call`)
+`last-call-deadline`: _The date last call period ends on_ (Optional field, only needed when status is `Last Call`)
 
-`type`: *One of `Standards Track`, `Meta`, or `Informational`*
+`type`: _One of `Standards Track`, `Meta`, or `Informational`_
 
-`category`: *One of `Core`, `Networking`, `Interface`, or `ERC`* (Optional field, only needed for `Standards Track` EIPs)
+`category`: _One of `Core`, `Networking`, `Interface`, or `ERC`_ (Optional field, only needed for `Standards Track` EIPs)
 
-`created`: *Date the EIP was created on*
+`created`: _Date the EIP was created on_
 
-`requires`: *EIP number(s)* (Optional field)
+`requires`: _EIP number(s)_ (Optional field)
 
-`withdrawal-reason`: *A sentence explaining why the EIP was withdrawn.* (Optional field, only needed when status is `Withdrawn`)
+`withdrawal-reason`: _A sentence explaining why the EIP was withdrawn._ (Optional field, only needed when status is `Withdrawn`)
 
 Headers that permit lists must separate elements with commas.
 
@@ -194,7 +199,7 @@ A `requires` dependency is created when the current EIP cannot be understood or 
 
 ## Linking to External Resources
 
-Other than the specific exceptions listed below, links to external resources **SHOULD NOT** be included. External resources may disappear, move, or change unexpectedly.
+Other than the specific exceptions listed below, links to external resources should not be included. External resources may disappear, move, or change unexpectedly.
 
 The process governing permitted external resources is described in [EIP-5757](./eip-5757.md).
 
@@ -304,7 +309,7 @@ Which renders as:
 
 [Secure Contexts](https://www.w3.org/TR/2021/CRD-secure-contexts-20210918/)
 
-Permitted W3C recommendation URLs MUST anchor to a specification in the technical reports namespace with a date, and so MUST match this regular expression:
+Permitted W3C recommendation URLs must anchor to a specification in the technical reports namespace with a date, and so must match this regular expression:
 
 ```regex
 ^https://www\.w3\.org/TR/[0-9][0-9][0-9][0-9]/.*$
@@ -342,7 +347,7 @@ Which renders as:
 
 [RFC 8446](https://www.rfc-editor.org/rfc/rfc8446)
 
-Permitted IETF specification URLs MUST anchor to a specification with an assigned RFC number (meaning cannot reference internet drafts), and so MUST match this regular expression:
+Permitted IETF specification URLs must anchor to a specification with an assigned RFC number (meaning cannot reference internet drafts), and so must match this regular expression:
 
 ```regex
 ^https:\/\/www.rfc-editor.org\/rfc\/.*$
@@ -509,7 +514,7 @@ The top-level URL field must resolve to a copy of the referenced document which 
 
 ## Linking to other EIPs
 
-References to other EIPs should follow the format `EIP-N` where `N` is the EIP number you are referring to.  Each EIP that is referenced in an EIP **MUST** be accompanied by a relative markdown link the first time it is referenced, and **MAY** be accompanied by a link on subsequent references.  The link **MUST** always be done via relative paths so that the links work in this GitHub repository, forks of this repository, the main EIPs site, mirrors of the main EIP site, etc.  For example, you would link to this EIP as `./eip-1.md`.
+References to other EIPs should follow the format `EIP-N` where `N` is the EIP number you are referring to. Each EIP that is referenced in an EIP must be accompanied by a relative markdown link the first time it is referenced, and may be accompanied by a link on subsequent references. The link must always be done via relative paths so that the links work in this GitHub repository, forks of this repository, the main EIPs site, mirrors of the main EIP site, etc. For example, you would link to this EIP as `./eip-1.md`.
 
 ## Auxiliary Files
 
@@ -585,11 +590,15 @@ The `description` field in the preamble:
 
 When referring to an EIP with a `category` of `ERC`, it must be written in the hyphenated form `ERC-X` where `X` is that EIP's assigned number. When referring to EIPs with any other `category`, it must be written in the hyphenated form `EIP-X` where `X` is that EIP's assigned number.
 
-### RFC 2119 and RFC 8174
+### All Capitalized Words via RFC 2119 and RFC 8174
 
-EIPs are encouraged to follow [RFC 2119](https://www.ietf.org/rfc/rfc2119.html) and [RFC 8174](https://www.ietf.org/rfc/rfc8174.html) for terminology and to insert the following at the beginning of the Specification section:
+EIPs are encouraged to declare a choice about whether words that are all-capitalized as specified in [RFC 2119](https://www.ietf.org/rfc/rfc2119.html) and [RFC 8174](https://www.ietf.org/rfc/rfc8174.html) for terminology are in effect and declare that choice in the EIP's Specification section. As a general guide, more dense technical EIPs such as Standard Track EIPs might be candidates to use RFC 2119 while EIPs that are Meta or Informational might not. There is no firm rule and this choice is ultimately up to the EIP authors and editors.
 
-> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+If the key words are in use, then insert at the beginning of the Specification section:
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+If the key words are not in use, then insert at the beginning of the Specification section:
+All capitalized key words as described in RFC 2119 and RFC 8174 are deliberately not in use in this document. For example “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” are not in use.
 
 ## History
 


### PR DESCRIPTION

### Proposed Changes to EIP-1

This pull request proposes modifications to EIP-1 to clarify the use of all-capitalized key words as specified in RFC 2119 and RFC 8174 for new EIPs and for EIP-1 itself. The key changes include:

1. **Specification Section Addition**:
   - Added a new Specification section at the top of EIP-1, declaring that all capitalized key words as described in RFC 2119 and RFC 8174 are deliberately not in use in this document.
   - Added a section in the Style Guide for how to make this choice on a case by case basis depending on EIP type and how to declare the choice made in the EIP.

### Rationale and Benefits:

- **Clarity**: Ensures that the use of RFC 2119 key words is explicitly stated in new EIPs and EIP-1 itself, improving the reader's understanding of the document's intent and style.
- **Consistency**: Encourages EIP authors to use these key words deliberately and correctly or not at all, enhancing the quality of technical documentation while maintaining flexibility.
- **Transparency**: Clearly stating the choice at the beginning of the EIP avoids any confusion later in the document and mitigates casual usage.
- **Exemplification**: Declaring usage up front in EIP-1 exemplifies for other EIPs the correct way to treat this and the benefits of clarity in doing so.

### Challenges:

- **Verification**: Ensuring that the current usage in EIP-1 adheres to the specified choice might require a more detailed review depending on EIP-1's original authors intent. In this pull request I have combed through and modified them all to be lowercase as I declared them not in use in the Specifications. 
- **Ensuring Clarity in Specifications**: declaring the absence of RFC 2119 usage may be distracting to readers and ultimately unnecessary. It may be easier to simply have EIP-1 require authors make a choice and then only declare it if it is in use.

By clarifying the use of all-capitalized key words, this proposal aims to improve the readability and precision of Ethereum’s technical documentation while still allowing transparency and choice for EIP writers. 
